### PR TITLE
Update `req` method on the REST client

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ContainerSpec {
     image: String,
@@ -11,7 +11,7 @@ pub struct ContainerSpec {
     environment: Option<HashMap<String, String>>,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum ImagePullPolicy {
     IfNotPresent,

--- a/src/events.rs
+++ b/src/events.rs
@@ -2,14 +2,14 @@ use crate::{meta::ObjectMeta, worker::WorkerPhase};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Event {
     metadata: Option<ObjectMeta>,
     worker_phases: Option<Vec<WorkerPhase>>,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EventSubscription {
     source: String,
@@ -17,14 +17,14 @@ pub struct EventSubscription {
     labels: HashMap<String, String>,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct EventsSelector {
     project_id: Option<String>,
     worker_phases: Option<Vec<WorkerPhase>>,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GitDetails {
     clone_url: Option<String>,
@@ -33,13 +33,13 @@ pub struct GitDetails {
     reference: Option<String>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct CancelManyEventsResult {
     count: i32,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DeleteManyEventsResult {
     count: i32,

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -1,27 +1,27 @@
 use serde::{Deserialize, Serialize};
 use serde_with::*;
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ObjectMeta {
     pub id: String,
     pub created: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct TypeMeta {
     pub kind: Kind,
     pub api_version: APIVersion,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub enum APIVersion {
     #[serde(rename = "brigade.sh/v2")]
     V2,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub enum Kind {
     Token,
     Project,

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::*;
 
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Project {
     pub metadata: ObjectMeta,
@@ -23,7 +23,7 @@ pub struct Project {
 }
 
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ProjectSpec {
     pub event_subscriptions: Option<Vec<EventSubscription>>,
@@ -31,7 +31,7 @@ pub struct ProjectSpec {
 }
 
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct KubernetesDetails {
     namespace: Option<String>,
@@ -49,26 +49,30 @@ impl ProjectsClient {
 
     pub async fn get(&self, id: String) -> Result<Project, Error> {
         let url = format!("{}/v2/projects/{}", self.client.address, id);
-        let none_opt: Option<&EmptyBody> = None;
-        let res = self.client.req(url, Method::GET, none_opt).await?;
+        let res = self
+            .client
+            .req(url, Method::GET, None::<&EmptyBody>)
+            .await?;
         let project: Project = serde_json::from_str(&res.text().await?.to_string())?;
         Ok(project)
     }
 
-    pub async fn create(&self, project: &mut Project) -> Result<Project, Error> {
+    pub async fn create(&self, project: &Project) -> Result<Project, Error> {
         let url = format!("{}/v2/projects", self.client.address);
-        self.ensure_project_meta(project);
+        let mut project = project.clone();
+        self.ensure_project_meta(&mut project);
         let res = self.client.req(url, Method::POST, Some(&project)).await?;
         let project: Project = serde_json::from_str(&res.text().await?.to_string())?;
         Ok(project)
     }
 
-    pub async fn update(&self, project: &mut Project) -> Result<Project, Error> {
+    pub async fn update(&self, project: &Project) -> Result<Project, Error> {
         let url = format!(
             "{}/v2/projects/{}",
             self.client.address, project.metadata.id
         );
-        self.ensure_project_meta(project);
+        let mut project = project.clone();
+        self.ensure_project_meta(&mut project);
         let res = self.client.req(url, Method::PUT, Some(&project)).await?;
         let str = &res.text().await?.to_string();
         let project: Project = serde_json::from_str(str)?;
@@ -127,7 +131,7 @@ mod test {
         console.log("Hello, World!")
     "#;
         default_config_files.insert("brigade.js".to_string(), val.to_string());
-        let mut project = Project {
+        let project = Project {
             metadata: ObjectMeta {
                 id: String::from("hello-rust-sdk"),
                 created: None,
@@ -150,7 +154,7 @@ mod test {
             kubernetes: None,
         };
 
-        let project = pc.create(&mut project).await.unwrap();
+        let project = pc.create(&project).await.unwrap();
         println!("{:#?}", project);
     }
 
@@ -165,7 +169,7 @@ mod test {
         let mut p = pc.get("hello-rust-sdk".to_string()).await.unwrap();
         p.description = Some("totally new descrption".to_string());
 
-        pc.update(&mut p).await.unwrap();
+        pc.update(&p).await.unwrap();
     }
 
     async fn get_token(address: String, cfg: ClientConfig) -> Token {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -5,7 +5,7 @@ use serde_with::*;
 use std::collections::HashMap;
 
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkerSpec {
     pub container: Option<ContainerSpec>,
@@ -19,7 +19,7 @@ pub struct WorkerSpec {
 }
 
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct GitConfig {
     #[serde(rename = "cloneURL")]
@@ -30,21 +30,21 @@ pub struct GitConfig {
 }
 
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct KubernetesConfig {
     image_pull_secrets: Option<Vec<String>>,
 }
 
 #[skip_serializing_none]
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct JobPolicies {
     allow_provileged: Option<bool>,
     allow_docker_soecket_mount: Option<bool>,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub enum LogLevel {
     #[serde(rename = "DEBUG")]
     Debug,
@@ -56,7 +56,7 @@ pub enum LogLevel {
     Error,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub enum WorkerPhase {
     #[serde(rename = "ABORTED")]
     Aborted,


### PR DESCRIPTION
This commit updates the `req` method on the REST client to take an
`Option<&T>`, so callers can use a single method regardless of whether
they need to send a body or not.

The method will probably have to accept headers and query params in the
same way, but so far we don't need them.
