### PR TITLE
Update request function on the REST client

### DIFF
--- a/src/authn.rs
+++ b/src/authn.rs
@@ -1,8 +1,9 @@
 use crate::{
     meta::TypeMeta,
-    rest::{Client, ClientConfig},
+    rest::{Client, ClientConfig, Empty},
 };
 use anyhow::Error;
+use hyper::Method;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
@@ -28,14 +29,17 @@ impl SessionsClient {
         let url = format!("{}/v2/sessions", self.client.address);
         let res = self
             .client
-            .rest
-            .post(&url)
-            .query(&[("root", "true")])
-            .basic_auth("root", Some(pwd))
-            .send()
+            .req_with_basic_auth(
+                url,
+                Method::POST,
+                None::<&Empty>,
+                Some(&[("root", "true")]),
+                None,
+                String::from("root"),
+                Some(pwd),
+            )
             .await?;
         let token: Token = serde_json::from_str(&res.text().await?.to_string())?;
-
         Ok(token)
     }
 }

--- a/src/authn.rs
+++ b/src/authn.rs
@@ -1,9 +1,9 @@
 use crate::{
     meta::TypeMeta,
-    rest::{Client, ClientConfig, Empty},
+    rest::{Client, ClientConfig},
 };
 use anyhow::Error;
-use hyper::Method;
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
@@ -29,15 +29,10 @@ impl SessionsClient {
         let url = format!("{}/v2/sessions", self.client.address);
         let res = self
             .client
-            .req_with_basic_auth(
-                url,
-                Method::POST,
-                None::<&Empty>,
-                Some(&[("root", "true")]),
-                None,
-                String::from("root"),
-                Some(pwd),
-            )
+            .req(Method::POST, &url)
+            .query(&[("root", "true")])
+            .basic_auth(String::from("root"), Some(pwd))
+            .send()
             .await?;
         let token: Token = serde_json::from_str(&res.text().await?.to_string())?;
         Ok(token)

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -64,11 +64,6 @@ impl ProjectsClient {
 
     pub async fn get(&self, id: String) -> Result<Project, Error> {
         let url = format!("{}/v2/projects/{}", self.client.address, id);
-        // let res = self
-        //     .client
-        //     .req(url, Method::GET, None::<&Empty>, None::<&Empty>, None)
-        //     .await?;
-
         let res = self.client.req(Method::GET, &url).send().await?;
         let project: Project = serde_json::from_str(&res.text().await?.to_string())?;
         Ok(project)
@@ -158,7 +153,6 @@ mod test {
             String::from("A project created from the Brigade Rust SDK"),
             script,
         );
-
         let project = pc.create(&project).await.unwrap();
         println!("{:#?}", project);
     }
@@ -173,7 +167,6 @@ mod test {
         let pc = ProjectsClient::new(String::from(address), cfg, Some(token.value)).unwrap();
         let mut p = pc.get("hello-rust-sdk".to_string()).await.unwrap();
         p.description = Some("totally new descrption".to_string());
-
         pc.update(&p).await.unwrap();
     }
 
@@ -183,7 +176,6 @@ mod test {
             .create_root_session("F00Bar!!!".to_string())
             .await
             .unwrap();
-
         token
     }
 }

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -23,14 +23,14 @@ pub struct Project {
 }
 
 impl Project {
-    pub fn default(id: String, description: String, script: String) -> Self {
+    pub fn new(id: String, description: String, script: String) -> Self {
         Project {
             metadata: ObjectMeta { id, created: None },
             type_meta: None,
             description: Some(description),
             spec: ProjectSpec {
                 event_subscriptions: None,
-                worker_template: WorkerSpec::default(script),
+                worker_template: WorkerSpec::new(script),
             },
             kubernetes: None,
         }
@@ -147,7 +147,7 @@ mod test {
         console.log("Hello, World!")
     "#
         .to_string();
-        let project = Project::default(
+        let project = Project::new(
             String::from("hello-rust-sdk"),
             String::from("A project created from the Brigade Rust SDK"),
             script,

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -1,7 +1,7 @@
 use crate::{
     events::EventSubscription,
     meta::{APIVersion, Kind, ObjectMeta, TypeMeta},
-    rest::{Client, ClientConfig, EmptyBody},
+    rest::{Client, ClientConfig, Empty},
     worker::WorkerSpec,
 };
 use anyhow::{Error, Result};
@@ -20,6 +20,21 @@ pub struct Project {
     pub description: Option<String>,
     pub spec: ProjectSpec,
     pub kubernetes: Option<KubernetesDetails>,
+}
+
+impl Project {
+    pub fn default(id: String, description: String, script: String) -> Self {
+        Project {
+            metadata: ObjectMeta { id, created: None },
+            type_meta: None,
+            description: Some(description),
+            spec: ProjectSpec {
+                event_subscriptions: None,
+                worker_template: WorkerSpec::default(script),
+            },
+            kubernetes: None,
+        }
+    }
 }
 
 #[skip_serializing_none]
@@ -51,7 +66,7 @@ impl ProjectsClient {
         let url = format!("{}/v2/projects/{}", self.client.address, id);
         let res = self
             .client
-            .req(url, Method::GET, None::<&EmptyBody>)
+            .req(url, Method::GET, None::<&Empty>, None::<&Empty>, None)
             .await?;
         let project: Project = serde_json::from_str(&res.text().await?.to_string())?;
         Ok(project)
@@ -61,7 +76,10 @@ impl ProjectsClient {
         let url = format!("{}/v2/projects", self.client.address);
         let mut project = project.clone();
         self.ensure_project_meta(&mut project);
-        let res = self.client.req(url, Method::POST, Some(&project)).await?;
+        let res = self
+            .client
+            .req(url, Method::POST, Some(&project), None::<&Empty>, None)
+            .await?;
         let project: Project = serde_json::from_str(&res.text().await?.to_string())?;
         Ok(project)
     }
@@ -73,7 +91,10 @@ impl ProjectsClient {
         );
         let mut project = project.clone();
         self.ensure_project_meta(&mut project);
-        let res = self.client.req(url, Method::PUT, Some(&project)).await?;
+        let res = self
+            .client
+            .req(url, Method::PUT, Some(&project), None::<&Empty>, None)
+            .await?;
         let str = &res.text().await?.to_string();
         let project: Project = serde_json::from_str(str)?;
         Ok(project)
@@ -94,15 +115,11 @@ impl ProjectsClient {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
-
     use crate::{
         authn::SessionsClient,
         authn::Token,
-        meta::ObjectMeta,
-        projects::{Project, ProjectSpec, ProjectsClient},
+        projects::{Project, ProjectsClient},
         rest::ClientConfig,
-        worker::WorkerSpec,
     };
 
     #[tokio::test]
@@ -126,33 +143,15 @@ mod test {
         let token = get_token(String::from(address), cfg.clone()).await;
         let pc = ProjectsClient::new(String::from(address), cfg, Some(token.value)).unwrap();
 
-        let mut default_config_files: HashMap<String, String> = HashMap::new();
-        let val = r#"
+        let script = r#"
         console.log("Hello, World!")
-    "#;
-        default_config_files.insert("brigade.js".to_string(), val.to_string());
-        let project = Project {
-            metadata: ObjectMeta {
-                id: String::from("hello-rust-sdk"),
-                created: None,
-            },
-            type_meta: None,
-            description: Some(String::from("A project created from the Brigade Rust SDK")),
-            spec: ProjectSpec {
-                event_subscriptions: None,
-                worker_template: WorkerSpec {
-                    container: None,
-                    use_workspace: None,
-                    workspace_size: None,
-                    git: None,
-                    job_policies: None,
-                    log_level: None,
-                    config_files_directory: None,
-                    default_config_files: Some(default_config_files),
-                },
-            },
-            kubernetes: None,
-        };
+    "#
+        .to_string();
+        let project = Project::default(
+            String::from("hello-rust-sdk"),
+            String::from("A project created from the Brigade Rust SDK"),
+            script,
+        );
 
         let project = pc.create(&project).await.unwrap();
         println!("{:#?}", project);

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -116,12 +116,8 @@ impl ProjectsClient {
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        authn::SessionsClient,
-        authn::Token,
-        projects::{Project, ProjectsClient},
-        rest::ClientConfig,
-    };
+    use super::*;
+    use crate::{authn::SessionsClient, authn::Token, rest::ClientConfig};
 
     #[tokio::test]
     async fn test_get_project() {

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -1,8 +1,5 @@
 use crate::error::BrigadeError;
-use hyper::{HeaderMap, Method};
-use reqwest::{RequestBuilder, Response};
-use serde::{Deserialize, Serialize};
-use serde_with::*;
+use reqwest::{IntoUrl, Method, RequestBuilder};
 
 #[derive(Debug, Clone)]
 pub struct ClientConfig {
@@ -42,66 +39,11 @@ impl Client {
         })
     }
 
-    pub async fn req<T: Serialize + ?Sized, Q: Serialize + ?Sized>(
-        &self,
-        url: String,
-        method: Method,
-        body: Option<&T>,
-        query: Option<&Q>,
-        headers: Option<HeaderMap>,
-    ) -> Result<Response, BrigadeError> {
-        let req = self.create_req(url, method, body, query, headers);
-
-        let res = req.send().await?;
-        Ok(res)
-    }
-
-    pub async fn req_with_basic_auth<T: Serialize + ?Sized, Q: Serialize + ?Sized>(
-        &self,
-        url: String,
-        method: Method,
-        body: Option<&T>,
-        query: Option<&Q>,
-        headers: Option<HeaderMap>,
-        user: String,
-        pwd: Option<String>,
-    ) -> Result<Response, BrigadeError> {
-        let req = self.create_req(url, method, body, query, headers);
-        let res = req.basic_auth(user, pwd).send().await?;
-        Ok(res)
-    }
-
-    fn create_req<T: Serialize + ?Sized, Q: Serialize + ?Sized>(
-        &self,
-        url: String,
-        method: Method,
-        body: Option<&T>,
-        query: Option<&Q>,
-        headers: Option<HeaderMap>,
-    ) -> RequestBuilder {
-        let mut req = self.rest.request(method, &url);
-        req = match self.token.clone() {
+    pub fn req<U: IntoUrl>(&self, method: Method, url: U) -> RequestBuilder {
+        let req = self.rest.request(method, url);
+        match self.token.clone() {
             Some(t) => req.bearer_auth(t),
             None => req,
-        };
-        req = match body {
-            Some(b) => req.json(b),
-            None => req,
-        };
-        req = match query {
-            Some(q) => req.query(q),
-            None => req,
-        };
-        req = match headers {
-            Some(h) => req.headers(h),
-            None => req,
-        };
-
-        req
+        }
     }
 }
-
-#[skip_serializing_none]
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct Empty {}

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -19,7 +19,7 @@ pub struct Client {
     pub config: ClientConfig,
     pub address: String,
     pub token: Option<String>,
-    pub rest: reqwest::Client,
+    rest: reqwest::Client,
 }
 
 impl Client {
@@ -41,7 +41,7 @@ impl Client {
 
     pub fn req<U: IntoUrl>(&self, method: Method, url: U) -> RequestBuilder {
         let req = self.rest.request(method, url);
-        match self.token.clone() {
+        match self.token.as_ref() {
             Some(t) => req.bearer_auth(t),
             None => req,
         }

--- a/src/rest.rs
+++ b/src/rest.rs
@@ -10,7 +10,7 @@ pub struct ClientConfig {
 }
 
 impl ClientConfig {
-    pub fn default() -> Self {
+    pub fn new() -> Self {
         Self {
             allow_insecure_connections: false,
         }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -19,7 +19,7 @@ pub struct WorkerSpec {
 }
 
 impl WorkerSpec {
-    pub fn default(script: String) -> Self {
+    pub fn new(script: String) -> Self {
         let mut default_config_files: HashMap<String, String> = HashMap::new();
         default_config_files.insert("brigade.js".to_string(), script);
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -18,6 +18,24 @@ pub struct WorkerSpec {
     pub default_config_files: Option<HashMap<String, String>>,
 }
 
+impl WorkerSpec {
+    pub fn default(script: String) -> Self {
+        let mut default_config_files: HashMap<String, String> = HashMap::new();
+        default_config_files.insert("brigade.js".to_string(), script);
+
+        WorkerSpec {
+            container: None,
+            use_workspace: None,
+            workspace_size: None,
+            git: None,
+            job_policies: None,
+            log_level: None,
+            config_files_directory: None,
+            default_config_files: Some(default_config_files),
+        }
+    }
+}
+
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
This commit updates the `req` to include the option to pass query params
and headers.
It also adds default methods to some structs to simplify initialization.
