### PR TITLE
Add GitHub Action for building the SDK

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,27 @@
+name: Rust
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    # We currently don't have mocking infrastructure for unit testing.
+    # The tests assume a port forwarding session has been started on
+    # locally to the Brigade API server.
+    # Once we add a way to mock the client requests, we should enable 
+    # the unit tests.
+    # - name: Run tests
+    #   run: cargo test --verbose


### PR DESCRIPTION
We currently don't have mocking infrastructure for unit testing.The tests assume a port forwarding session has been started locally to the Brigade API server.
Once we add a way to mock the client requests, we should enable the unit tests.